### PR TITLE
jobs/build: Skip --tag functionality for non-master streams

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -385,26 +385,37 @@ lock(resource: "build-${params.STREAM}") {
 
         // Kola QEMU tests
         parallelruns['Kola:QEMU'] = {
-            // remove 1 for upgrade test
-            def n = ncpus - 1
-            shwrap("""
-            cosa kola run --rerun --parallel ${n} --no-test-exit-error --denylist-test basic --tag '!reprovision'
-            cosa shell -- tar -c --xz tmp/kola/ > kola-run.tar.xz
-            cosa shell -- cat tmp/kola/reports/report.json > report.json
-            """)
-            archiveArtifacts "kola-run.tar.xz"
-            if (!pipeutils.checkKolaSuccess("report.json")) {
-                error('Kola:QEMU')
-            }
-            shwrap("""
-            cosa shell -- rm -rf tmp/kola
-            cosa kola run --rerun --no-test-exit-error --tag reprovision
-            cosa shell -- tar -c --xz tmp/kola/ > kola-run-reprovision.tar.xz
-            cosa shell -- cat tmp/kola/reports/report.json > report.json
-            """)
-            archiveArtifacts "kola-run-reprovision.tar.xz"
-            if (!pipeutils.checkKolaSuccess("report.json")) {
-                error('Kola:QEMU')
+            if (params.STREAM == "master") {
+                // remove 1 for upgrade test
+                def n = ncpus - 1
+                shwrap("""
+                cosa kola run --rerun --parallel ${n} --no-test-exit-error --denylist-test basic --tag '!reprovision'
+                cosa shell -- tar -c --xz tmp/kola/ > kola-run.tar.xz
+                cosa shell -- cat tmp/kola/reports/report.json > report.json
+                """)
+                archiveArtifacts "kola-run.tar.xz"
+                if (!pipeutils.checkKolaSuccess("report.json")) {
+                    error('Kola:QEMU')
+                }
+                shwrap("""
+                cosa shell -- rm -rf tmp/kola
+                cosa kola run --rerun --no-test-exit-error --tag reprovision
+                cosa shell -- tar -c --xz tmp/kola/ > kola-run-reprovision.tar.xz
+                cosa shell -- cat tmp/kola/reports/report.json > report.json
+                """)
+                archiveArtifacts "kola-run-reprovision.tar.xz"
+                if (!pipeutils.checkKolaSuccess("report.json")) {
+                    error('Kola:QEMU')
+                }
+            } else {
+                shwrap("""
+                cosa shell -- tar -c --xz tmp/kola/ > kola-run.tar.xz
+                cosa shell -- cat tmp/kola/reports/report.json > report.json
+                """)
+                archiveArtifacts "kola-run.tar.xz"
+                if (!pipeutils.checkKolaSuccess("report.json")) {
+                    error('Kola:QEMU')
+                }
             }
         }
 


### PR DESCRIPTION
We don't have functionality for `--tag` in 4.11 or older versions.